### PR TITLE
feat: support new az field + gcp cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	provider = api.ClusterProviderGoogle
+	provider = api.ClusterProviderGCP
 )
 
 func newConfiguration(provider api.ClusterProvider) *api.Configuration {
 	switch provider {
-	case api.ClusterProviderGoogle:
+	case api.ClusterProviderGCP:
 		kubeconfigPath := os.Getenv("KUBECONFIG")
 
 		return &api.Configuration{

--- a/pkg/api/aws.go
+++ b/pkg/api/aws.go
@@ -385,7 +385,10 @@ type AWSWorker struct {
 	// Annotations specifies labels for the Kubernetes node objects
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
-	Spec        AWSWorkerSpec     `json:"spec"`
+	// IsMultiAZ defines if a node group should be split across the availability zones. If false, will create a node group per AZ
+	// +optional
+	IsMultiAZ bool          `json:"isMultiAZ,omitempty"`
+	Spec      AWSWorkerSpec `json:"spec"`
 }
 
 type AWSWorkerSpec struct {

--- a/pkg/api/azure.go
+++ b/pkg/api/azure.go
@@ -114,7 +114,10 @@ type AzureWorker struct {
 	KubernetesVersion *string           `json:"kubernetesVersion,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
 	Annotations       map[string]string `json:"annotations,omitempty"`
-	Spec              AzureWorkerSpec   `json:"spec"`
+	// IsMultiAZ defines if a node group should be split across the availability zones. If false, will create a node group per AZ
+	// +optional
+	IsMultiAZ bool            `json:"isMultiAZ,omitempty"`
+	Spec      AzureWorkerSpec `json:"spec"`
 }
 
 type AzureWorkerSpec struct {

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -4,10 +4,10 @@ type ClusterProvider string
 type ClusterType string
 
 const (
-	ClusterProviderAWS    = ClusterProvider("aws")
-	ClusterProviderAzure  = ClusterProvider("azure")
-	ClusterProviderGoogle = ClusterProvider("google")
-	ClusterProviderKind   = ClusterProvider("kind")
+	ClusterProviderAWS   = ClusterProvider("aws")
+	ClusterProviderAzure = ClusterProvider("azure")
+	ClusterProviderGCP   = ClusterProvider("gcp")
+	ClusterProviderKind  = ClusterProvider("kind")
 
 	ClusterTypeManaged   = ClusterType("managed")
 	ClusterTypeUnmanaged = ClusterType("unmanaged")
@@ -38,7 +38,7 @@ type Cluster struct {
 type CloudSpec struct {
 	AWSCloudSpec   *AWSCloudSpec   `json:"aws,omitempty"`
 	AzureCloudSpec *AzureCloudSpec `json:"azure,omitempty"`
-	GCPCloudSpec   *GCPCloudSpec   `json:"google,omitempty"`
+	GCPCloudSpec   *GCPCloudSpec   `json:"gcp,omitempty"`
 }
 
 type Workers struct {
@@ -49,11 +49,11 @@ type Workers struct {
 type WorkersSpec struct {
 	AWSWorkers   *AWSWorkers   `json:"aws,omitempty"`
 	AzureWorkers *AzureWorkers `json:"azure,omitempty"`
-	GCPWorkers   *GCPWorkers   `json:"google,omitempty"`
+	GCPWorkers   *GCPWorkers   `json:"gcp,omitempty"`
 }
 
 type DefaultsWorker struct {
 	AWSDefaultWorker   *AWSWorker   `json:"aws,omitempty"`
 	AzureDefaultWorker *AzureWorker `json:"azure,omitempty"`
-	GCPDefaultWorker   *GCPWorker   `json:"google,omitempty"`
+	GCPDefaultWorker   *GCPWorker   `json:"gcp,omitempty"`
 }

--- a/pkg/api/gcp.go
+++ b/pkg/api/gcp.go
@@ -73,7 +73,17 @@ type GCPCloudSpec struct {
 type GCPWorkers map[string]GCPWorker
 
 type GCPWorker struct {
-	Replicas         *int32               `json:"replicas,omitempty"`
+	Replicas          *int32            `json:"replicas,omitempty"`
+	KubernetesVersion *string           `json:"kubernetesVersion,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	// IsMultiAZ defines if a node group should be split across the availability zones. If false, will create a node group per AZ
+	// +optional
+	IsMultiAZ bool          `json:"isMultiAZ,omitempty"`
+	Spec      GCPWorkerSpec `json:"spec"`
+}
+
+type GCPWorkerSpec struct {
 	Scaling          *GCPWorkerScaling    `json:"scaling,omitempty"`
 	Management       *GCPWorkerManagement `json:"management,omitempty"`
 	KubernetesLabels *Labels              `json:"kubernetesLabels,omitempty"`

--- a/pkg/aws/accessor.go
+++ b/pkg/aws/accessor.go
@@ -533,6 +533,7 @@ func (this *ClusterAccessor) GetWorkers() (*api.Workers, error) {
 		Defaults: api.DefaultsWorker{
 			AWSDefaultWorker: &api.AWSWorker{
 				Replicas:    0,
+				IsMultiAZ:   false,
 				Annotations: map[string]string{"cluster.x-k8s.io/replicas-managed-by": "external-autoscaler"},
 				Spec: api.AWSWorkerSpec{
 					Labels:         map[string]*string{},
@@ -573,6 +574,7 @@ func (this *ClusterAccessor) GetWorkers() (*api.Workers, error) {
 			Replicas:    int(*nodeGroup.Nodegroup.ScalingConfig.DesiredSize),
 			Labels:      nil,
 			Annotations: nil,
+			IsMultiAZ:   true, // default to true so that the availability zones we discovered are used
 			Spec: api.AWSWorkerSpec{
 				Labels:       nodeGroup.Nodegroup.Labels,
 				AMIVersion:   "", //amiVersion.Version,

--- a/pkg/azure/worker/defaults.go
+++ b/pkg/azure/worker/defaults.go
@@ -11,6 +11,7 @@ func Defaults() *api.AzureWorker {
 		Annotations: map[string]string{
 			"cluster.x-k8s.io/replicas-managed-by": "external-autoscaler",
 		},
+		IsMultiAZ: false,
 		Spec: api.AzureWorkerSpec{
 			Mode:              "User",
 			SKU:               "Standard_D2s_v3",

--- a/pkg/azure/worker/worker.go
+++ b/pkg/azure/worker/worker.go
@@ -1,9 +1,10 @@
 package worker
 
 import (
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	"github.com/pluralsh/cluster-api-migration/pkg/api"
-	"strings"
 )
 
 type Workers struct {
@@ -60,6 +61,7 @@ func Worker(agentPool containerservice.ManagedClusterAgentPoolProfile) api.Azure
 		Replicas:          int(*agentPool.Count),
 		KubernetesVersion: agentPool.OrchestratorVersion,
 		Annotations:       map[string]string{},
+		IsMultiAZ:         true, // default to true so that the availability zones we discovered are used
 		Spec: api.AzureWorkerSpec{
 			AdditionalTags:       agentPool.Tags,
 			Mode:                 string(agentPool.Mode),

--- a/pkg/gcp/migrator.go
+++ b/pkg/gcp/migrator.go
@@ -40,7 +40,7 @@ func (this *Migrator) Convert() (*api.Values, error) {
 	}
 
 	return &api.Values{
-		Provider: api.ClusterProviderGoogle,
+		Provider: api.ClusterProviderGCP,
 		Type:     api.ClusterTypeManaged,
 		Cluster:  *c,
 		Workers:  *w,

--- a/pkg/gcp/worker/defaults.go
+++ b/pkg/gcp/worker/defaults.go
@@ -4,16 +4,19 @@ import "github.com/pluralsh/cluster-api-migration/pkg/api"
 
 func (this *Workers) defaults() *api.GCPWorker {
 	return &api.GCPWorker{
-		Scaling: &api.GCPWorkerScaling{
-			MaxCount: 6,
-			MinCount: 3,
+		IsMultiAZ: false,
+		Spec: api.GCPWorkerSpec{
+			Scaling: &api.GCPWorkerScaling{
+				MaxCount: 6,
+				MinCount: 3,
+			},
+			KubernetesLabels: &api.Labels{},
+			AdditionalLabels: &api.Labels{},
+			KubernetesTaints: &api.Taints{},
+			ProviderIDList:   []string{},
+			MachineType:      "e2-standard-2",
+			DiskSizeGb:       50,
+			DiskType:         "pd-standard",
 		},
-		KubernetesLabels: &api.Labels{},
-		AdditionalLabels: &api.Labels{},
-		KubernetesTaints: &api.Taints{},
-		ProviderIDList:   []string{},
-		MachineType:      "e2-standard-2",
-		DiskSizeGb:       50,
-		DiskType:         "pd-standard",
 	}
 }

--- a/pkg/gcp/worker/workers.go
+++ b/pkg/gcp/worker/workers.go
@@ -45,19 +45,25 @@ func (this *Workers) toGCPWorker(nodePool *containerpb.NodePool) api.GCPWorker {
 	}
 
 	return api.GCPWorker{
-		Replicas:         this.getReplicasForNodePool(nodePool.Name),
-		Scaling:          autoscaling,
-		Management:       management,
-		KubernetesLabels: this.kubernetesLabels(nodePool),
-		AdditionalLabels: this.additionalLabels(nodePool),
-		KubernetesTaints: this.kubernetesTaints(nodePool),
-		ProviderIDList:   this.providerIDList(nodePool),
-		MachineType:      nodePool.Config.MachineType,
-		DiskSizeGb:       nodePool.Config.DiskSizeGb,
-		DiskType:         nodePool.Config.DiskType,
-		ImageType:        nodePool.Config.ImageType,
-		Preemptible:      nodePool.Config.Preemptible,
-		Spot:             nodePool.Config.Spot,
+		Replicas:          this.getReplicasForNodePool(nodePool.Name),
+		KubernetesVersion: nil,
+		Labels:            nil,
+		Annotations:       nil,
+		IsMultiAZ:         true, // default to true so that the availability zones we discovered are used
+		Spec: api.GCPWorkerSpec{
+			Scaling:          autoscaling,
+			Management:       management,
+			KubernetesLabels: this.kubernetesLabels(nodePool),
+			AdditionalLabels: this.additionalLabels(nodePool),
+			KubernetesTaints: this.kubernetesTaints(nodePool),
+			ProviderIDList:   this.providerIDList(nodePool),
+			MachineType:      nodePool.Config.MachineType,
+			DiskSizeGb:       nodePool.Config.DiskSizeGb,
+			DiskType:         nodePool.Config.DiskType,
+			ImageType:        nodePool.Config.ImageType,
+			Preemptible:      nodePool.Config.Preemptible,
+			Spot:             nodePool.Config.Spot,
+		},
 	}
 }
 

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -12,7 +12,7 @@ import (
 
 func NewMigrator(provider api.ClusterProvider, config *api.Configuration) (api.Migrator, error) {
 	switch provider {
-	case api.ClusterProviderGoogle:
+	case api.ClusterProviderGCP:
 		return gcp.NewGCPMigrator(config.GCPConfiguration)
 	case api.ClusterProviderAzure:
 		return azure.NewAzureMigrator(config.AzureConfiguration)


### PR DESCRIPTION
This PR adds the changes required with the new `isMultiAZ` field on node groups that allows for easily splitting a node group definition across the different availability zones when set to `false`. This is set to `true` by default during migration so that we don't change anything about the node groups we've gotten from the cluster.

It also changes the name of the GCP configurations from `google` to `gcp` so it is consistent with the other providers, as well as changing the GCP machine pool specs so that it is defined the same as is currently done for AWS and Azure.